### PR TITLE
Expires

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ This package is 100% port of Python built-in function `functools.lru_cache <http
 
 Python 3.3+ is required
 
+Plus it supports keyword argument `expires` that expire the cached item after certain number of seconds.
+
 Thanks
 ------
 

--- a/tests/test_expires.py
+++ b/tests/test_expires.py
@@ -1,0 +1,47 @@
+import asyncio
+
+import pytest
+
+from async_lru import alru_cache
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_expires(check_lru, loop):
+    @alru_cache(maxsize=4, expires=0.2, loop=loop)
+    async def coro(val):
+        return val
+
+    value = 1
+
+    assert await coro(value) == value
+    check_lru(coro, hits=0, misses=1, cache=1, tasks=0, maxsize=4)
+
+    await asyncio.sleep(0.1, loop=loop)
+    assert await coro(value) == value
+    check_lru(coro, hits=1, misses=1, cache=1, tasks=0, maxsize=4)
+
+    await asyncio.sleep(0.3, loop=loop)
+    # cache is clear after time expires
+    check_lru(coro, hits=1, misses=1, cache=0, tasks=0, maxsize=4)
+    assert await coro(value) == value
+    check_lru(coro, hits=1, misses=2, cache=1, tasks=0, maxsize=4)
+
+
+async def test_expires_maxsize(check_lru, loop):
+    @alru_cache(maxsize=1, expires=0.2, loop=loop)
+    async def coro(val):
+        return val
+
+    assert await coro(1) == 1
+    check_lru(coro, hits=0, misses=1, cache=1, tasks=0, maxsize=1)
+
+    assert await coro(2) == 2
+    check_lru(coro, hits=0, misses=2, cache=1, tasks=0, maxsize=1)
+
+    await asyncio.sleep(0.1, loop=loop)
+    assert await coro(2) == 2
+    check_lru(coro, hits=1, misses=2, cache=1, tasks=0, maxsize=1)
+
+    assert await coro(1) == 1
+    check_lru(coro, hits=1, misses=3, cache=1, tasks=0, maxsize=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Thank you for this great package!

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This change adds keyword argument `expires` as discussed in https://github.com/aio-libs/async_lru/pull/50#issuecomment-487609639. In comparison with the other implementation this removes the key from the cache immediately after `expires` time passes. This way it saves the space earlier and we don't have to deal with special cases with `maxsize` (if we don't call the coroutine with the same arguments again the already expired item would take place in `_cache` forever or until it is removed by least recently used principle.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Everything behaves in the same manner plus user can use the new keyword argument.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
This PR has no issue number.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes

