### PR TITLE
Adding cache_pop

### DIFF
--- a/async_lru.py
+++ b/async_lru.py
@@ -56,6 +56,10 @@ def _cache_clear(wrapped):
     wrapped.tasks = set()
 
 
+def _cache_pop(wrapped, key):
+    del wrapped._cache[key]
+
+
 def _open(wrapped):
     if not wrapped.closed:
         raise RuntimeError('alru_cache is not closed')
@@ -241,6 +245,7 @@ def alru_cache(
         wrapped.closed = False
         wrapped.cache_info = partial(_cache_info, wrapped, maxsize)
         wrapped.cache_clear = partial(_cache_clear, wrapped)
+        wrapped.cache_pop = partial(_cache_pop, wrapped)
         wrapped.invalidate = partial(_cache_invalidate, wrapped, typed)
         wrapped.close = partial(_close, wrapped)
         wrapped.open = partial(_open, wrapped)


### PR DESCRIPTION
Added `cache_pop`, allowing to delete a single element of the cache 🎉 

### Usage : 
```python
from async_lru import alru_cache

@alru_cache()
async def coro(val):
    return val

await coro(1)
await coro(2)
await coro(3)

print(coro.cache_info())
# CacheInfo(hits=0, misses=3, maxsize=128, currsize=3)

coro.cache_pop(2) # Remove 2 from cache
print(coro.cache_info())
# CacheInfo(hits=0, misses=3, maxsize=128, currsize=2)
```

