### PR TITLE
Remove use of @asyncio.coroutine, deprecated in python 3.8

### DIFF
--- a/async_lru.py
+++ b/async_lru.py
@@ -187,8 +187,7 @@ def alru_cache(
             fn = fn._make_unbound_method()
 
         @wraps(fn)
-        @asyncio.coroutine
-        def wrapped(*fn_args, **fn_kwargs):
+        async def wrapped(*fn_args, **fn_kwargs):
             if wrapped.closed:
                 raise RuntimeError(
                     'alru_cache is closed for {}'.format(wrapped))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -142,8 +142,7 @@ async def test_alru_cache_await_same_result_coroutine(check_lru, loop):
     val = object()
 
     @alru_cache(loop=loop)
-    @asyncio.coroutine
-    def coro():
+    async def coro():
         nonlocal calls
         calls += 1
 


### PR DESCRIPTION
Other parts of the code were already using async def, too, and the python versions that didn't support this are EOL.

<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes `DeprecationWarning`s when using this library

## Are there changes in behavior for the user?

Fewer warnings.

## Related issue number

#142

Not updating the `loop` argument warnings, since it only affects the tests and seems to rely on that behavior.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder *(there's no CHANGES folder?)*
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`

(there's no CHANGES folder?)