### PR TITLE
Drop old @coroutine and `yield from` syntax

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -142,8 +142,7 @@ async def test_alru_cache_await_same_result_coroutine(check_lru, loop):
     val = object()
 
     @alru_cache(loop=loop)
-    @asyncio.coroutine
-    def coro():
+    async def coro():
         nonlocal calls
         calls += 1
 


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Dropping old `@coroutine` syntax because of Python 3.8 deprecation.

## Are there changes in behavior for the user?

No known changes.

## Related issue number

Fixes #212 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
