### PR TITLE
feat(support): cython `cython_function_or_method` support

### DIFF
--- a/async_lru.py
+++ b/async_lru.py
@@ -126,7 +126,11 @@ def alru_cache(
     def wrapper(fn):
         _origin = unpartial(fn)
 
-        if not asyncio.iscoroutinefunction(_origin):
+        # NOTE: cython_function_or_method support for Cython
+        # with unecessary cython package installation
+        _is_cython_function = type(fn).__qualname__ == 'cython_function_or_method'
+
+        if not asyncio.iscoroutinefunction(_origin) and not _is_cython_function:
             raise RuntimeError("Coroutine function is required, got {}".format(fn))
 
         # functools.partialmethod support


### PR DESCRIPTION
## What do these changes do?

This PR adds support for cython function `cython_function_or_method` .

## The problem:

After compilation with cythonize, cython change the type of coroutine functions to `cython_function_or_method`, type which is not included on [line 129](https://github.com/aio-libs/async-lru/blob/master/async_lru.py#L129-L130)

Output:

```
Traceback (most recent call last):
  ...
  File "async_lru.py", line 130, in wrapper
    raise RuntimeError("Coroutine function is required, got {}".format(fn))
RuntimeError: Coroutine function is required, got <cyfunction ... at 0x7f9ac6717100>
```

## Are there changes in behavior for the user?
After compilation with Cython, this module will work :)

<!-- Outline any notable behaviour for the end users. -->

## Checklist

- [x] I think the code is well written
