### PR TITLE
add py.typed to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
 include LICENSE
+include async_lru/py.typed
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
## What do these changes do?

adds `py.typed` to the `.tar.gz`

## Are there changes in behavior for the user?

users of `sdist`-based downstreams (such as [conda-forge](https://github.com/conda-forge/async-lru-feedstock/pull/3)) will get proper typing support

## Related issue number

- #470

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
