### PR TITLE
fix #480, concurrent cache access with ttl

### DIFF
--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -159,9 +159,8 @@ class _LRUCacheWrapper(Generic[_R]):
     ) -> None:
         self.__tasks.remove(task)
 
-        if self.__ttl is not None:
+        if self.__ttl is not None and (cache_item := self.__cache.get(key)):
             loop = asyncio.get_running_loop()
-            cache_item = self.__cache[key]
             cache_item.later_call = loop.call_later(
                 self.__ttl, self.__cache.pop, key, None
             )

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -159,7 +159,8 @@ class _LRUCacheWrapper(Generic[_R]):
     ) -> None:
         self.__tasks.remove(task)
 
-        if self.__ttl is not None and (cache_item := self.__cache.get(key)):
+        cache_item = self.__cache.get(key)
+        if self.__ttl is not None and cache_item is not None:
             loop = asyncio.get_running_loop()
             cache_item.later_call = loop.call_later(
                 self.__ttl, self.__cache.pop, key, None

--- a/tests/test_ttl.py
+++ b/tests/test_ttl.py
@@ -58,3 +58,12 @@ async def test_ttl_with_explicit_invalidation(check_lru: Callable[..., None]) ->
     # cache is not cleared after ttl expires because invalidate also should clear
     # the invalidation by timeout
     check_lru(coro, hits=0, misses=2, cache=1, tasks=0, maxsize=None)
+
+
+async def test_ttl_concurrent() -> None:
+    @alru_cache(maxsize=1, ttl=1)
+    async def coro(val: int) -> int:
+        return val
+
+    results = await asyncio.gather(*[coro(i) for i in range(2)])
+    assert results == list(range(2))

--- a/tests/test_ttl.py
+++ b/tests/test_ttl.py
@@ -66,4 +66,4 @@ async def test_ttl_concurrent() -> None:
         return val
 
     results = await asyncio.gather(*(coro(i) for i in range(2)))
-    assert results == tuple(range(2))
+    assert results == list(range(2))

--- a/tests/test_ttl.py
+++ b/tests/test_ttl.py
@@ -65,5 +65,5 @@ async def test_ttl_concurrent() -> None:
     async def coro(val: int) -> int:
         return val
 
-    results = await asyncio.gather(*[coro(i) for i in range(2)])
-    assert results == list(range(2))
+    results = await asyncio.gather(*(coro(i) for i in range(2)))
+    assert results == tuple(range(2))


### PR DESCRIPTION
## What do these changes do?

Fix key error when concurrent access to cache with ttl and max_size enabled

## Related issue number

Fixes #480 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist

