### PR TITLE
Use ParamSpec for wrapped signatures

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,24 @@
+[mypy]
+files = async_lru, tests
+check_untyped_defs = True
+follow_imports_for_stubs = True
+disallow_any_decorated = True
+disallow_any_generics = True
+disallow_any_unimported = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+enable_error_code = ignore-without-code, possibly-undefined, redundant-expr, redundant-self, truthy-bool, truthy-iterable, unused-awaitable
+implicit_reexport = False
+no_implicit_optional = True
+pretty = True
+show_column_numbers = True
+show_error_codes = True
+strict_equality = True
+warn_incomplete_stub = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+warn_unused_ignores = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,9 +78,3 @@ testpaths = tests/
 junit_family=xunit2
 asyncio_mode=auto
 timeout=15
-
-
-[mypy]
-strict=True
-pretty=True
-packages=async_lru, tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,18 @@
 from functools import _CacheInfo
-from typing import Callable
+from typing import Callable, ParamSpec, TypeVar
 
 import pytest
 
-from async_lru import _R, _LRUCacheWrapper
+from async_lru import _LRUCacheWrapper
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 
 @pytest.fixture
-def check_lru() -> Callable[..., None]:
+def check_lru() -> Callable[..., None]:  # type: ignore[misc]
     def _check_lru(
-        wrapped: _LRUCacheWrapper[_R],
+        wrapped: _LRUCacheWrapper[_P, _T],
         *,
         hits: int,
         misses: int,


### PR DESCRIPTION
There are still a couple of issues with this.

1. Typing doesn't seem to work correctly with instance methods. Not sure exactly what is going wrong here, needs some more investigation.
2. `partial()` use will cause new type errors. We can either wait until partial() is supported by typedshed/mypy (https://github.com/python/typeshed/issues/8703 / https://github.com/python/mypy/issues/1484), or we could expose a `TypeAlias` of `_LRUCacheWrapper` so it can be used in type annotations.