### PR TITLE
Feature/ignore args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,3 +14,8 @@ CHANGES
 
 - Fixed a ``KeyError`` that could occur when using ``ttl`` with ``maxsize``.
 - Dropped ``typing-extensions`` dependency in Python 3.11+.
+
+2.1.0 (2023-09-12)
+==================
+
+- Add ``ignore_args``

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,15 @@ parameter (off by default):
     async def func(arg):
         return arg * 2
 
+Ignorable arguments are supported by accepting `ignore_args` configuration
+parameter (off by default). This can be useful when want to pass an argument to the cached function but don't want it to be considered when performing cache key lookups:
+
+.. code-block:: python
+
+    @alru_cache(ignore_args=["client_arg"])
+    async def func(client_arg, value_arg):
+        return client_arg.do(value_arg)
+
 
 The library supports explicit invalidation for specific function call by
 `cache_invalidate()`:

--- a/README.rst
+++ b/README.rst
@@ -77,16 +77,6 @@ parameter (off by default):
     async def func(arg):
         return arg * 2
 
-Ignorable arguments are supported by accepting `ignore_args` configuration
-parameter (off by default). This can be useful when want to pass an argument to the cached function but don't want it to be considered when performing cache key lookups:
-
-.. code-block:: python
-
-    @alru_cache(ignore_args=["client_arg"])
-    async def func(client_arg, value_arg):
-        return client_arg.do(value_arg)
-
-
 The library supports explicit invalidation for specific function call by
 `cache_invalidate()`:
 
@@ -100,6 +90,16 @@ The library supports explicit invalidation for specific function call by
 
 The method returns `True` if corresponding arguments set was cached already, `False`
 otherwise.
+
+Ignorable arguments are supported by accepting `ignore_args` configuration
+parameter (off by default). This can be useful when want to pass an argument to the cached function but don't want it to be considered when performing cache key lookups:
+
+.. code-block:: python
+
+    @alru_cache(ignore_args=["client_arg"])
+    async def func(client_arg, value_arg):
+        return client_arg.do(value_arg)
+
 
 
 Python 3.8+ is required

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -196,10 +196,8 @@ class _LRUCacheWrapper(Generic[_R]):
 
         key = _make_key(fn_args, fn_kwargs, self.__typed)
 
-        cache_item = self.__cache.get(key)
-
-        return_future = None
         with self.__lookup_mutex:
+            cache_item = self.__cache.get(key)
             if cache_item is not None:
                 if not cache_item.fut.done():
                     self._cache_hit(key)

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -2,7 +2,6 @@ import asyncio
 import dataclasses
 import sys
 from asyncio.coroutines import _is_coroutine  # type: ignore[attr-defined]
-from threading import Thread, Lock
 from functools import _CacheInfo, _make_key, partial, partialmethod
 from typing import (
     Any,
@@ -106,7 +105,6 @@ class _LRUCacheWrapper(Generic[_R]):
         self.__hits = 0
         self.__misses = 0
         self.__tasks: Set["asyncio.Task[_R]"] = set()
-        self.__lookup_mutex = Lock()
 
     def cache_invalidate(self, /, *args: Hashable, **kwargs: Any) -> bool:
         key = _make_key(args, kwargs, self.__typed)
@@ -196,55 +194,37 @@ class _LRUCacheWrapper(Generic[_R]):
 
         key = _make_key(fn_args, fn_kwargs, self.__typed)
 
-        with self.__lookup_mutex:
-            cache_item = self.__cache.get(key)
-            if cache_item is not None:
-                if not cache_item.fut.done():
-                    self._cache_hit(key)
-                    return_future = asyncio.shield(cache_item.fut)
-                else:
-                    exc = cache_item.fut._exception
+        cache_item = self.__cache.get(key)
 
-                    if exc is None:
-                        self._cache_hit(key)
-                        return cache_item.fut.result()
-                    else:
-                        # exception here
-                        cache_item = self.__cache.pop(key)
-                        cache_item.cancel()
-                        fut = loop.create_future()
-                        coro = self.__wrapped__(*fn_args, **fn_kwargs)
-                        task: asyncio.Task[_R] = loop.create_task(coro)
-                        self.__tasks.add(task)
-                        task.add_done_callback(partial(self._task_done_callback, fut, key))
+        if cache_item is not None:
+            if not cache_item.fut.done():
+                self._cache_hit(key)
+                return await asyncio.shield(cache_item.fut)
 
-                        self.__cache[key] = _CacheItem(fut, None)
+            exc = cache_item.fut._exception
 
-                        if self.__maxsize is not None and len(self.__cache) > self.__maxsize:
-                            dropped_key, cache_item = self.__cache.popitem(last=False)
-                            cache_item.cancel()
-
-                        self._cache_miss(key)
-                        return_future = asyncio.shield(fut)
+            if exc is None:
+                self._cache_hit(key)
+                return cache_item.fut.result()
             else:
-                fut = loop.create_future()
-                coro = self.__wrapped__(*fn_args, **fn_kwargs)
-                task: asyncio.Task[_R] = loop.create_task(coro)
-                self.__tasks.add(task)
-                task.add_done_callback(partial(self._task_done_callback, fut, key))
+                # exception here
+                cache_item = self.__cache.pop(key)
+                cache_item.cancel()
 
-                self.__cache[key] = _CacheItem(fut, None)
+        fut = loop.create_future()
+        coro = self.__wrapped__(*fn_args, **fn_kwargs)
+        task: asyncio.Task[_R] = loop.create_task(coro)
+        self.__tasks.add(task)
+        task.add_done_callback(partial(self._task_done_callback, fut, key))
 
-                if self.__maxsize is not None and len(self.__cache) > self.__maxsize:
-                    dropped_key, cache_item = self.__cache.popitem(last=False)
-                    cache_item.cancel()
+        self.__cache[key] = _CacheItem(fut, None)
 
-                self._cache_miss(key)
-                return_future = asyncio.shield(fut)
-        return await return_future
+        if self.__maxsize is not None and len(self.__cache) > self.__maxsize:
+            dropped_key, cache_item = self.__cache.popitem(last=False)
+            cache_item.cancel()
 
-
-
+        self._cache_miss(key)
+        return await asyncio.shield(fut)
 
     def __get__(
         self, instance: _T, owner: Optional[Type[_T]]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ flake8-bandit==4.1.1
 flake8-bugbear==23.7.10
 flake8-import-order==0.18.2
 flake8-requirements==1.7.8
-mypy==1.5.0; implementation_name=="cpython"
+mypy==1.5.1; implementation_name=="cpython"

--- a/tests/test_ignore_args.py
+++ b/tests/test_ignore_args.py
@@ -1,0 +1,38 @@
+import asyncio
+from typing import Callable
+
+import pytest
+
+from async_lru import alru_cache
+
+
+async def test_ignore_args_cache(check_lru: Callable[..., None]) -> None:
+    @alru_cache(maxsize=None, ignore_args=['val1'])
+    async def coro(val1: int, val2: int) -> int:
+        return val1 + val2
+
+    assert await coro(1, 2) == 3
+    check_lru(coro, hits=0, misses=1, cache=1, tasks=0, maxsize=None)
+    await asyncio.sleep(0.0)
+    # since we are ignoring val1, it should return the previous cached result (3)
+    assert await coro(2, 2) == 3
+    check_lru(coro, hits=1, misses=1, cache=1, tasks=0, maxsize=None)
+
+
+async def test_ignore_args_kwargs_cache(check_lru: Callable[..., None]) -> None:
+    @alru_cache(maxsize=None, ignore_args=['val1'])
+    async def coro(val1: int, val2: int) -> int:
+        return val1 + val2
+
+    assert await coro(val2=2, val1=1) == 3
+    check_lru(coro, hits=0, misses=1, cache=1, tasks=0, maxsize=None)
+    await asyncio.sleep(0.0)
+    # since we are ignoring val1, it should return the previous cached result (3)
+    assert await coro(val2=2, val1=2) == 3
+    check_lru(coro, hits=1, misses=1, cache=1, tasks=0, maxsize=None)
+
+async def test_ignore_args_arg_does_not_exist(check_lru: Callable[..., None]) -> None:
+    with pytest.raises(ValueError):
+        @alru_cache(ignore_args=["asd"])
+        async def coro(val: int) -> int:
+            return val

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -8,7 +8,7 @@ from async_lru import _LRUCacheWrapper
 
 
 async def test_done_callback_cancelled() -> None:
-    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
+    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None, None)
     loop = asyncio.get_running_loop()
     task = loop.create_future()
     fut = loop.create_future()
@@ -26,7 +26,7 @@ async def test_done_callback_cancelled() -> None:
 
 
 async def test_done_callback_exception() -> None:
-    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
+    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None, None)
     loop = asyncio.get_running_loop()
     task = loop.create_future()
     fut = loop.create_future()
@@ -52,7 +52,7 @@ async def test_done_callback_exception() -> None:
 
 
 async def test_done_callback() -> None:
-    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None)
+    wrapped = _LRUCacheWrapper(mock.ANY, None, False, None, None)
     loop = asyncio.get_running_loop()
     task = loop.create_future()
 
@@ -70,7 +70,7 @@ async def test_done_callback() -> None:
 
 
 async def test_cache_invalidate_typed() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
 
     from_cache = wrapped.cache_invalidate(1, a=1)
 
@@ -95,7 +95,7 @@ async def test_cache_invalidate_typed() -> None:
 
 
 async def test_cache_invalidate_not_typed() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, False, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, False, None, None)
 
     from_cache = wrapped.cache_invalidate(1, a=1)
     assert not from_cache
@@ -116,7 +116,7 @@ async def test_cache_invalidate_not_typed() -> None:
 
 
 async def test_cache_clear() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
 
     await wrapped(123)
 
@@ -140,7 +140,7 @@ async def test_cache_clear() -> None:
 
 
 def test_cache_info() -> None:
-    wrapped = _LRUCacheWrapper(mock.ANY, 3, True, None)
+    wrapped = _LRUCacheWrapper(mock.ANY, 3, True, None, None)
 
     assert (0, 0, 3, 0) == wrapped.cache_info()
 
@@ -156,7 +156,7 @@ def test_cache_info() -> None:
 
 
 async def test_cache_hit() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
     await wrapped(1)
     assert wrapped.cache_info().hits == 0
     assert wrapped.cache_info().misses == 1
@@ -169,7 +169,7 @@ async def test_cache_hit() -> None:
 
 
 async def test_cache_miss() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
     await wrapped(1)
     assert wrapped.cache_info().hits == 0
     assert wrapped.cache_info().misses == 1
@@ -182,7 +182,7 @@ async def test_cache_miss() -> None:
 
 
 async def test_forbid_call_closed() -> None:
-    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None)
+    wrapped = _LRUCacheWrapper(mock.AsyncMock(return_value=1), None, True, None, None)
     wrapped._LRUCacheWrapper__closed = True  # type: ignore[attr-defined]
     with pytest.raises(RuntimeError):
         await wrapped(123)


### PR DESCRIPTION
## What do these changes do?

This PR adds the `ignore_args` argument to the decorator.

## Are there changes in behavior for the user?

This will allow the user to ignore specific args from the cache key logic allowing the user to use those arguments in the wrapped function but not have them impact cache lookups. This works for args and kwags and is disabled by default.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`

I added a `2.1.0` to the CHANGES.rst, the above instructions did not make sense to me.