### PR TITLE
Fix memory leak on exception caching

### DIFF
--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -222,6 +222,7 @@ class _LRUCacheWrapper(Generic[_R]):
         if self.__maxsize is not None and len(self.__cache) > self.__maxsize:
             dropped_key, cache_item = self.__cache.popitem(last=False)
             cache_item.cancel()
+            del cache_item
 
         self._cache_miss(key)
         return await asyncio.shield(fut)

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,5 +1,6 @@
 import asyncio
 import gc
+import sys
 from typing import Callable
 
 import pytest
@@ -28,8 +29,13 @@ async def test_alru_exception(check_lru: Callable[..., None]) -> None:
     check_lru(coro, hits=2, misses=2, cache=1, tasks=0)
 
 
+@pytest.mark.skipif(
+    reason="Memory leak is not fixed for PyPy3.9",
+    condition=sys.implementation.name == "pypy",
+)
 async def test_alru_exception_reference_cleanup(check_lru: Callable[..., None]) -> None:
-    class CustomClass: ...
+    class CustomClass:
+        ...
 
     @alru_cache()
     async def coro(val: int) -> None:

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 from typing import Callable
 
 import pytest
@@ -25,3 +26,25 @@ async def test_alru_exception(check_lru: Callable[..., None]) -> None:
         await coro(1)
 
     check_lru(coro, hits=2, misses=2, cache=1, tasks=0)
+
+
+async def test_alru_exception_reference_cleanup(check_lru: Callable[..., None]) -> None:
+    class CustomClass: ...
+
+    @alru_cache()
+    async def coro(val: int) -> None:
+        leaky = CustomClass()
+        1 / 0
+
+    coros = [coro(v) for v in range(1000)]
+
+    await asyncio.gather(*coros, return_exceptions=True)
+
+    check_lru(coro, hits=0, misses=1000, cache=128, tasks=0)
+
+    await asyncio.sleep(0.00001)
+    gc.collect()
+
+    assert (
+        len([obj for obj in gc.get_objects() if isinstance(obj, CustomClass)]) == 128
+    ), "Only objects in the cache should be left in memory."

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -39,7 +39,7 @@ async def test_alru_exception_reference_cleanup(check_lru: Callable[..., None]) 
 
     @alru_cache()
     async def coro(val: int) -> None:
-        leaky = CustomClass()
+        _ = CustomClass()  # object we are verifying not to leak
         1 / 0
 
     coros = [coro(v) for v in range(1000)]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
When exception is "evicted" from cache, if following call raises an exception, both of them will be kept in memory introducing a memory leak.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
[199](https://github.com/aio-libs/async-lru/pull/199) is probably related

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
