### PR TITLE
Remove keys from cache on exception

### DIFF
--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -31,13 +31,13 @@ async def test_cache_close(check_lru: Callable[..., None]) -> None:
 
     await close
 
-    check_lru(coro, hits=0, misses=5, cache=5, tasks=0)
+    check_lru(coro, hits=0, misses=5, cache=0, tasks=0)
     assert coro.cache_parameters()["closed"]
 
     with pytest.raises(asyncio.CancelledError):
         await gather
 
-    check_lru(coro, hits=0, misses=5, cache=5, tasks=0)
+    check_lru(coro, hits=0, misses=5, cache=0, tasks=0)
     assert coro.cache_parameters()["closed"]
 
     # double call is no-op

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -29,7 +29,7 @@ async def test_alru_exception(check_lru: Callable[..., None]) -> None:
     check_lru(coro, hits=2, misses=2, cache=0, tasks=0)
 
 
-@pytest.mark.skipif(
+@pytest.mark.xfail(
     reason="Memory leak is not fixed for PyPy3.9",
     condition=sys.implementation.name == "pypy",
 )

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,4 +1,6 @@
 import asyncio
+import gc
+import sys
 from typing import Callable
 
 import pytest
@@ -16,7 +18,7 @@ async def test_alru_exception(check_lru: Callable[..., None]) -> None:
 
     ret = await asyncio.gather(*coros, return_exceptions=True)
 
-    check_lru(coro, hits=2, misses=1, cache=1, tasks=0)
+    check_lru(coro, hits=2, misses=1, cache=0, tasks=0)
 
     for item in ret:
         assert isinstance(item, ZeroDivisionError)
@@ -24,4 +26,31 @@ async def test_alru_exception(check_lru: Callable[..., None]) -> None:
     with pytest.raises(ZeroDivisionError):
         await coro(1)
 
-    check_lru(coro, hits=2, misses=2, cache=1, tasks=0)
+    check_lru(coro, hits=2, misses=2, cache=0, tasks=0)
+
+
+@pytest.mark.skipif(
+    reason="Memory leak is not fixed for PyPy3.9",
+    condition=sys.implementation.name == "pypy",
+)
+async def test_alru_exception_reference_cleanup(check_lru: Callable[..., None]) -> None:
+    class CustomClass:
+        ...
+
+    @alru_cache()
+    async def coro(val: int) -> None:
+        _ = CustomClass()  # object we are verifying not to leak
+        1 / 0
+
+    coros = [coro(v) for v in range(1000)]
+
+    await asyncio.gather(*coros, return_exceptions=True)
+
+    check_lru(coro, hits=0, misses=1000, cache=0, tasks=0)
+
+    await asyncio.sleep(0.00001)
+    gc.collect()
+
+    assert (
+        len([obj for obj in gc.get_objects() if isinstance(obj, CustomClass)]) == 0
+    ), "Only objects in the cache should be left in memory."


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Remove key from cache as soon as the task fails.
Currently, it removes the key from the cache on subsequent retrival.

Benefits:
- less unnecessary data in cache leading to smaller footprint and if the cache is full, less evictions keeping it more performant
- remove memory leak on exception happening

## Are there changes in behavior for the user?
No (only noticable change should be less data in cache stats `cache_info()`)

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
This PR can replace [595](https://github.com/aio-libs/async-lru/pull/594) one as there will be no more exeptions in cache stored.
This one introduces a bit more changes so if it is going in the wrong direction other one can be merged instead to remove memory leak only.

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
