### PR TITLE
Switch from asyncio.iscoroutinefunction to inspect.

### DIFF
--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import inspect
 import sys
 from asyncio.coroutines import _is_coroutine  # type: ignore[attr-defined]
 from functools import _CacheInfo, _make_key, partial, partialmethod
@@ -28,7 +29,6 @@ else:
     from typing_extensions import Self
 
 if sys.version_info >= (3, 14):
-    import inspect
     iscoroutinefunction = inspect.iscoroutinefunction
 else:
     iscoroutinefunction = asyncio.iscoroutinefunction

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -1,6 +1,6 @@
 import asyncio
 import dataclasses
-import inspect  # noqa: F401
+import inspect
 import sys
 from asyncio.coroutines import _is_coroutine  # type: ignore[attr-defined]
 from functools import _CacheInfo, _make_key, partial, partialmethod
@@ -27,11 +27,6 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
-
-if sys.version_info >= (3, 14):
-    iscoroutinefunction = inspect.iscoroutinefunction
-else:
-    iscoroutinefunction = asyncio.iscoroutinefunction
 
 
 __version__ = "2.0.4"
@@ -299,13 +294,14 @@ def _make_wrapper(
     typed: bool,
     ttl: Optional[float] = None,
 ) -> Callable[[_CBP[_R]], _LRUCacheWrapper[_R]]:
+    @inspect.markcoroutinefunction
     def wrapper(fn: _CBP[_R]) -> _LRUCacheWrapper[_R]:
         origin = fn
 
         while isinstance(origin, (partial, partialmethod)):
             origin = origin.func
 
-        if not iscoroutinefunction(origin):
+        if not inspect.iscoroutinefunction(origin):
             raise RuntimeError(f"Coroutine function is required, got {fn!r}")
 
         # functools.partialmethod support

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -1,6 +1,5 @@
 import asyncio
 import dataclasses
-import inspect
 import sys
 from asyncio.coroutines import _is_coroutine  # type: ignore[attr-defined]
 from functools import _CacheInfo, _make_key, partial, partialmethod
@@ -29,6 +28,8 @@ else:
     from typing_extensions import Self
 
 if sys.version_info >= (3, 14):
+    import inspect
+
     iscoroutinefunction = inspect.iscoroutinefunction
 else:
     iscoroutinefunction = asyncio.iscoroutinefunction

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -27,6 +27,12 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
+if sys.version_info >= (3, 14):
+    import inspect
+    iscoroutinefunction = inspect.iscoroutinefunction
+else:
+    iscoroutinefunction = asyncio.iscoroutinefunction
+
 
 __version__ = "2.0.4"
 
@@ -299,7 +305,7 @@ def _make_wrapper(
         while isinstance(origin, (partial, partialmethod)):
             origin = origin.func
 
-        if not asyncio.iscoroutinefunction(origin):
+        if not iscoroutinefunction(origin):
             raise RuntimeError(f"Coroutine function is required, got {fn!r}")
 
         # functools.partialmethod support

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -294,37 +294,23 @@ def _make_wrapper(
     typed: bool,
     ttl: Optional[float] = None,
 ) -> Callable[[_CBP[_R]], _LRUCacheWrapper[_R]]:
-    if sys.version_info >= (3, 12):
-        @inspect.markcoroutinefunction
-        def wrapper(fn: _CBP[_R]) -> _LRUCacheWrapper[_R]:
-            origin = fn
-    
-            while isinstance(origin, (partial, partialmethod)):
-                origin = origin.func
-    
-            if not inspect.iscoroutinefunction(origin):
-                raise RuntimeError(f"Coroutine function is required, got {fn!r}")
-    
-            # functools.partialmethod support
-            if hasattr(fn, "_make_unbound_method"):
-                fn = fn._make_unbound_method()
-    
-            return _LRUCacheWrapper(cast(_CB[_R], fn), maxsize, typed, ttl)
-    else:
-        def wrapper(fn: _CBP[_R]) -> _LRUCacheWrapper[_R]:
-            origin = fn
-    
-            while isinstance(origin, (partial, partialmethod)):
-                origin = origin.func
-    
-            if not inspect.iscoroutinefunction(origin):
-                raise RuntimeError(f"Coroutine function is required, got {fn!r}")
-    
-            # functools.partialmethod support
-            if hasattr(fn, "_make_unbound_method"):
-                fn = fn._make_unbound_method()
-    
-            return _LRUCacheWrapper(cast(_CB[_R], fn), maxsize, typed, ttl)
+    def wrapper(fn: _CBP[_R]) -> _LRUCacheWrapper[_R]:
+        origin = fn
+
+        while isinstance(origin, (partial, partialmethod)):
+            origin = origin.func
+
+        if not inspect.iscoroutinefunction(origin):
+            raise RuntimeError(f"Coroutine function is required, got {fn!r}")
+
+        # functools.partialmethod support
+        if hasattr(fn, "_make_unbound_method"):
+            fn = fn._make_unbound_method()
+
+        wrapper = _LRUCacheWrapper(cast(_CB[_R], fn), maxsize, typed, ttl)
+        if sys.version_info >= (3, 12):
+            wrapper = inspect.markcoroutinefunction(wrapper)
+        return wrapper
 
     return wrapper
 

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -2,7 +2,6 @@ import asyncio
 import dataclasses
 import inspect
 import sys
-from asyncio.coroutines import _is_coroutine  # type: ignore[attr-defined]
 from functools import _CacheInfo, _make_key, partial, partialmethod
 from typing import (
     Any,
@@ -27,6 +26,9 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
+
+if sys.version_info < (3, 14):
+    from asyncio.coroutines import _is_coroutine  # type: ignore[attr-defined]
 
 
 __version__ = "2.0.5"

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import inspect  # noqa: F401
 import sys
 from asyncio.coroutines import _is_coroutine  # type: ignore[attr-defined]
 from functools import _CacheInfo, _make_key, partial, partialmethod
@@ -28,8 +29,6 @@ else:
     from typing_extensions import Self
 
 if sys.version_info >= (3, 14):
-    import inspect
-
     iscoroutinefunction = inspect.iscoroutinefunction
 else:
     iscoroutinefunction = asyncio.iscoroutinefunction

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -96,7 +96,8 @@ class _LRUCacheWrapper(Generic[_R]):
             pass
         # set __wrapped__ last so we don't inadvertently copy it
         # from the wrapped function when updating __dict__
-        self._is_coroutine = _is_coroutine
+        if sys.version_info < (3, 14):
+            self._is_coroutine = _is_coroutine
         self.__wrapped__ = fn
         self.__maxsize = maxsize
         self.__typed = typed
@@ -263,7 +264,8 @@ class _LRUCacheWrapperInstanceMethod(Generic[_R, _T]):
             pass
         # set __wrapped__ last so we don't inadvertently copy it
         # from the wrapped function when updating __dict__
-        self._is_coroutine = _is_coroutine
+        if sys.version_info < (3, 14):
+            self._is_coroutine = _is_coroutine
         self.__wrapped__ = wrapper.__wrapped__
         self.__instance = instance
         self.__wrapper = wrapper

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,8 @@ known_first_party=async_lru
 addopts= -s --keep-duplicates --cache-clear --verbose --no-cov-on-fail --cov=async_lru --cov=tests/ --cov-report=term --cov-report=html
 filterwarnings =
     error
-    ignore:.*'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
+    ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
+    ignore:'asyncio.set_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
 testpaths = tests/
 junit_family=xunit2
 asyncio_mode=auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ known_first_party=async_lru
 addopts= -s --keep-duplicates --cache-clear --verbose --no-cov-on-fail --cov=async_lru --cov=tests/ --cov-report=term --cov-report=html
 filterwarnings =
     error
-    ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
+    ignore:.*'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
 testpaths = tests/
 junit_family=xunit2
 asyncio_mode=auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ known_first_party=async_lru
 addopts= -s --keep-duplicates --cache-clear --verbose --no-cov-on-fail --cov=async_lru --cov=tests/ --cov-report=term --cov-report=html
 filterwarnings =
     error
+    ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio.plugin
 testpaths = tests/
 junit_family=xunit2
 asyncio_mode=auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ known_first_party=async_lru
 addopts= -s --keep-duplicates --cache-clear --verbose --no-cov-on-fail --cov=async_lru --cov=tests/ --cov-report=term --cov-report=html
 filterwarnings =
     error
-    ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio.plugin
+    ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
 testpaths = tests/
 junit_family=xunit2
 asyncio_mode=auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,9 @@ known_first_party=async_lru
 addopts= -s --keep-duplicates --cache-clear --verbose --no-cov-on-fail --cov=async_lru --cov=tests/ --cov-report=term --cov-report=html
 filterwarnings =
     error
+    ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
+    ignore:'asyncio.set_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
+    ignore:'asyncio.set_event_loop' is deprecated:DeprecationWarning:pytest_asyncio
 testpaths = tests/
 junit_family=xunit2
 asyncio_mode=auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ addopts= -s --keep-duplicates --cache-clear --verbose --no-cov-on-fail --cov=asy
 filterwarnings =
     error
     ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
+    ignore:'asyncio.set_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
     ignore:'asyncio.set_event_loop' is deprecated:DeprecationWarning:pytest_asyncio
 testpaths = tests/
 junit_family=xunit2

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,9 +74,6 @@ known_first_party=async_lru
 addopts= -s --keep-duplicates --cache-clear --verbose --no-cov-on-fail --cov=async_lru --cov=tests/ --cov-report=term --cov-report=html
 filterwarnings =
     error
-    ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
-    ignore:'asyncio.set_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
-    ignore:'asyncio.set_event_loop' is deprecated:DeprecationWarning:pytest_asyncio
 testpaths = tests/
 junit_family=xunit2
 asyncio_mode=auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ addopts= -s --keep-duplicates --cache-clear --verbose --no-cov-on-fail --cov=asy
 filterwarnings =
     error
     ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
-    ignore:'asyncio.set_event_loop_policy' is deprecated:DeprecationWarning:pytest_asyncio
+    ignore:'asyncio.set_event_loop' is deprecated:DeprecationWarning:pytest_asyncio
 testpaths = tests/
 junit_family=xunit2
 asyncio_mode=auto

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 import pytest
 
-from async_lru import _CacheParameters, alru_cache, iscoroutinefunction
+from async_lru import _CacheParameters, alru_cache
 
 
 def test_alru_cache_not_callable() -> None:
@@ -28,7 +28,7 @@ async def test_alru_cache_deco(check_lru: Callable[..., None]) -> None:
     async def coro() -> None:
         pass
 
-    assert iscoroutinefunction(coro)
+    assert inspect.iscoroutinefunction(coro)
 
     check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
 
@@ -42,7 +42,7 @@ async def test_alru_cache_deco_called(check_lru: Callable[..., None]) -> None:
     async def coro() -> None:
         pass
 
-    assert iscoroutinefunction(coro)
+    assert inspect.iscoroutinefunction(coro)
 
     check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
 
@@ -57,7 +57,7 @@ async def test_alru_cache_fn_called(check_lru: Callable[..., None]) -> None:
 
     coro_wrapped = alru_cache(coro)
 
-    assert iscoroutinefunction(coro_wrapped)
+    assert inspect.iscoroutinefunction(coro_wrapped)
 
     check_lru(coro_wrapped, hits=0, misses=0, cache=0, tasks=0)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import platform
 import sys
 from functools import _CacheInfo, partial
@@ -6,7 +7,7 @@ from typing import Callable
 
 import pytest
 
-from async_lru import _CacheParameters, alru_cache
+from async_lru import _CacheParameters, alru_cache, iscoroutinefunction
 
 
 def test_alru_cache_not_callable() -> None:
@@ -27,7 +28,7 @@ async def test_alru_cache_deco(check_lru: Callable[..., None]) -> None:
     async def coro() -> None:
         pass
 
-    assert asyncio.iscoroutinefunction(coro)
+    assert iscoroutinefunction(coro)
 
     check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
 
@@ -41,7 +42,7 @@ async def test_alru_cache_deco_called(check_lru: Callable[..., None]) -> None:
     async def coro() -> None:
         pass
 
-    assert asyncio.iscoroutinefunction(coro)
+    assert iscoroutinefunction(coro)
 
     check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
 
@@ -56,7 +57,7 @@ async def test_alru_cache_fn_called(check_lru: Callable[..., None]) -> None:
 
     coro_wrapped = alru_cache(coro)
 
-    assert asyncio.iscoroutinefunction(coro_wrapped)
+    assert iscoroutinefunction(coro_wrapped)
 
     check_lru(coro_wrapped, hits=0, misses=0, cache=0, tasks=0)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -30,6 +30,8 @@ async def test_alru_cache_deco(check_lru: Callable[..., None]) -> None:
 
     if sys.version_info >= (3, 12):
         assert inspect.iscoroutinefunction(coro)
+    if sys.version_info < (3, 14):
+        assert asyncio.iscoroutinefunction(coro)
 
     check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
 
@@ -45,6 +47,8 @@ async def test_alru_cache_deco_called(check_lru: Callable[..., None]) -> None:
 
     if sys.version_info >= (3, 12):
         assert inspect.iscoroutinefunction(coro)
+    if sys.version_info < (3, 14):
+        assert asyncio.iscoroutinefunction(coro)
 
     check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
 
@@ -61,6 +65,8 @@ async def test_alru_cache_fn_called(check_lru: Callable[..., None]) -> None:
 
     if sys.version_info >= (3, 12):
         assert inspect.iscoroutinefunction(coro_wrapped)
+    if sys.version_info < (3, 14):
+        assert asyncio.iscoroutinefunction(coro)
 
     check_lru(coro_wrapped, hits=0, misses=0, cache=0, tasks=0)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -28,7 +28,8 @@ async def test_alru_cache_deco(check_lru: Callable[..., None]) -> None:
     async def coro() -> None:
         pass
 
-    assert inspect.iscoroutinefunction(coro)
+    if sys.version_info >= (3, 12):
+        assert inspect.iscoroutinefunction(coro)
 
     check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
 
@@ -42,7 +43,8 @@ async def test_alru_cache_deco_called(check_lru: Callable[..., None]) -> None:
     async def coro() -> None:
         pass
 
-    assert inspect.iscoroutinefunction(coro)
+    if sys.version_info >= (3, 12):
+        assert inspect.iscoroutinefunction(coro)
 
     check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
 
@@ -57,7 +59,8 @@ async def test_alru_cache_fn_called(check_lru: Callable[..., None]) -> None:
 
     coro_wrapped = alru_cache(coro)
 
-    assert inspect.iscoroutinefunction(coro_wrapped)
+    if sys.version_info >= (3, 12):
+        assert inspect.iscoroutinefunction(coro_wrapped)
 
     check_lru(coro_wrapped, hits=0, misses=0, cache=0, tasks=0)
 


### PR DESCRIPTION
The former causes: DeprecationWarning:
'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead.

Fixes: https://github.com/aio-libs/async-lru/issues/635

## What do these changes do?

See the description in the commit message.

## Are there changes in behavior for the user?

No

## Related issue number

#635 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
