### PR TITLE
feat: dont reorganize __cache if unbounded

### DIFF
--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -162,7 +162,8 @@ class _LRUCacheWrapper(Generic[_R]):
 
     def _cache_hit(self, key: Hashable) -> None:
         self.__hits += 1
-        self.__cache.move_to_end(key)
+        if self.__maxsize is not None:
+            self.__cache.move_to_end(key)
 
     def _cache_miss(self, key: Hashable) -> None:
         self.__misses += 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

If a cache wrapper does not have a maxsize, there isn't any reason to reorganize the OrderedDict.

Let's wait until the codspeed stuff is merged before we look at this one.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

None.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

N/A

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
