### PR TITLE
fix(benchmark): adapt callback benchmark to lib conditions

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,4 +1,5 @@
 import asyncio
+from functools import partial
 from typing import Any, Callable
 
 import pytest
@@ -305,10 +306,10 @@ def test_internal_task_done_callback_microbenchmark(
 
     iterations = range(1000)
     create_future = loop.create_future
-    callback_getter = func._task_done_callback
+    callback_fn = func._task_done_callback
 
     @benchmark
     def run() -> None:
         for i in iterations:
-            callback = callback_getter(create_future(), i)
+            callback = partial(callback_fn, create_future(), i)
             callback(task)


### PR DESCRIPTION
## What do these changes do?
This PR adapts test_internal_task_done_callback_microbenchmark to the actual conditions seen in async-lru, namely the 2 step create-callback, call-callback procedure as opposed to the currently benchmarked all-at-once approach which bypasses the impact that functools.partial has on our actual execution times

## Are there changes in behavior for the user?
None

## Related issue number
N/A

## Checklist

- [x] I think the code is well written
