### PR TITLE
Fix/benchmark bugs

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -175,7 +175,7 @@ def test_cache_miss_benchmark(
 ) -> None:
     func = factory()
     # Use 2048 objects (16x maxsize=128) to force evictions and measure actual misses
-    unique_objects = [object() for _ in range(128)]
+    unique_objects = [object() for _ in range(2048)]
 
     async def run() -> None:
         for obj in unique_objects:
@@ -262,7 +262,7 @@ def test_concurrent_cache_hit_benchmark(
     async def gather_coros():
         gather = asyncio.gather
         for _ in range(10):
-            return await gather(*map(func, keys))
+            await gather(*map(func, keys))
 
     benchmark(run_loop, gather_coros)
 


### PR DESCRIPTION
## What do these changes do?

Fixed two logic bugs in `benchmark.py` that prevented accurate performance measurements:

1.  **Cache Miss Benchmark**: `test_cache_miss_benchmark` was previously improperly configured with only 128 distinct objects (matching the cache size), resulting in cache hits instead of misses. Increased the sample size to 2048 objects to ensure evictions and actual misses are measured.
2.  **Concurrent Hit Benchmark**: `test_concurrent_cache_hit_benchmark` contained a bug where the loop returned after the first iteration. Removed the premature return to ensure the benchmark runs for the intended 10 iterations.

## Are there changes in behavior for the user?

No. These changes only affect the internal benchmark suite used for performance verification.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
