### PR TITLE
enable slots with `_CacheItem`, `_LRUCacheWrapper` & `_LRUCacheWrapperInstanceMethod`

### DIFF
--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -52,7 +52,7 @@ class _CacheParameters(TypedDict):
 
 
 @final
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class _CacheItem(Generic[_R]):
     fut: "asyncio.Future[_R]"
     later_call: Optional[asyncio.Handle]

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -84,6 +84,7 @@ class _LRUCacheWrapper(Generic[_R]):
         "__misses",
         "__first_loop",
         "__warned_loop_reset",
+        "_is_coroutine",
     )
 
     def __init__(

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -314,6 +314,14 @@ class _LRUCacheWrapper(Generic[_R]):
 
 @final
 class _LRUCacheWrapperInstanceMethod(Generic[_R, _T]):
+    __slots__ = (
+        "__dict__",
+        "_is_coroutine",
+        "__wrapped__",
+        "__instance",
+        "__wrapper",
+    )
+
     def __init__(
         self,
         wrapper: _LRUCacheWrapper[_R],

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -72,6 +72,20 @@ class _CacheItem(Generic[_R]):
 
 @final
 class _LRUCacheWrapper(Generic[_R]):
+    __slots__ = (
+        "__wrapped__",
+        "__maxsize",
+        "__typed",
+        "__ttl",
+        "__jitter",
+        "__cache",
+        "__closed",
+        "__hits",
+        "__misses",
+        "__first_loop",
+        "__warned_loop_reset",
+    )
+
     def __init__(
         self,
         fn: _CB[_R],

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -85,6 +85,8 @@ class _LRUCacheWrapper(Generic[_R]):
         "__first_loop",
         "__warned_loop_reset",
         "_is_coroutine",
+        "_is_coroutine_marker",
+        "__dict__",
     )
 
     def __init__(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This Pull request improves async-lru by using slots on dataclass and also `__slots__` across the 2 other classes which helps eliminate some performance bottlenecks.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Other than performance benefits there are no behavioral changes to note.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
