### PR TITLE
Fix alru_cache crash with deferred annotations on Python 3.14

### DIFF
--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -99,10 +99,17 @@ class _LRUCacheWrapper(Generic[_R]):
             self.__doc__ = fn.__doc__
         except AttributeError:
             pass
+        # Python 3.14+ (PEP 649): copy the lazy __annotate__ function the
+        # way functools.update_wrapper does; reading fn.__annotations__
+        # would force evaluation of deferred annotations and fail on
+        # names that are not defined yet.
         try:
-            self.__annotations__ = fn.__annotations__
+            self.__annotate__ = fn.__annotate__  # type: ignore[attr-defined]
         except AttributeError:
-            pass
+            try:
+                self.__annotations__ = fn.__annotations__
+            except AttributeError:
+                pass
         try:
             self.__dict__.update(fn.__dict__)
         except AttributeError:
@@ -329,10 +336,15 @@ class _LRUCacheWrapperInstanceMethod(Generic[_R, _T]):
             self.__doc__ = wrapper.__doc__
         except AttributeError:
             pass
+        # Python 3.14+ (PEP 649): prefer the lazy __annotate__ function,
+        # see the matching logic in _LRUCacheWrapper.__init__.
         try:
-            self.__annotations__ = wrapper.__annotations__
+            self.__annotate__ = wrapper.__annotate__
         except AttributeError:
-            pass
+            try:
+                self.__annotations__ = wrapper.__annotations__
+            except AttributeError:
+                pass
         try:
             self.__dict__.update(wrapper.__dict__)
         except AttributeError:

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -99,12 +99,8 @@ class _LRUCacheWrapper(Generic[_R]):
             self.__doc__ = fn.__doc__
         except AttributeError:
             pass
-        # Python 3.14+ (PEP 649): copy the lazy __annotate__ function the
-        # way functools.update_wrapper does; reading fn.__annotations__
-        # would force evaluation of deferred annotations and fail on
-        # names that are not defined yet. The version gate keeps older
-        # interpreters on the plain __annotations__ copy with no
-        # try/except overhead for a missing __annotate__.
+        # Copy the lazy __annotate__ function; reading fn.__annotations__
+        # would force evaluation of deferred annotations (PEP 649).
         if sys.version_info >= (3, 14):
             try:
                 self.__annotate__ = fn.__annotate__
@@ -344,8 +340,8 @@ class _LRUCacheWrapperInstanceMethod(Generic[_R, _T]):
             self.__doc__ = wrapper.__doc__
         except AttributeError:
             pass
-        # Python 3.14+ (PEP 649): prefer the lazy __annotate__ function,
-        # see the matching logic in _LRUCacheWrapper.__init__.
+        # Prefer the lazy __annotate__ function, see the matching logic
+        # in _LRUCacheWrapper.__init__.
         if sys.version_info >= (3, 14):
             try:
                 self.__annotate__ = wrapper.__annotate__

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -102,10 +102,18 @@ class _LRUCacheWrapper(Generic[_R]):
         # Python 3.14+ (PEP 649): copy the lazy __annotate__ function the
         # way functools.update_wrapper does; reading fn.__annotations__
         # would force evaluation of deferred annotations and fail on
-        # names that are not defined yet.
-        try:
-            self.__annotate__ = fn.__annotate__  # type: ignore[attr-defined]
-        except AttributeError:
+        # names that are not defined yet. The version gate keeps older
+        # interpreters on the plain __annotations__ copy with no
+        # try/except overhead for a missing __annotate__.
+        if sys.version_info >= (3, 14):
+            try:
+                self.__annotate__ = fn.__annotate__
+            except AttributeError:
+                try:
+                    self.__annotations__ = fn.__annotations__
+                except AttributeError:
+                    pass
+        else:
             try:
                 self.__annotations__ = fn.__annotations__
             except AttributeError:
@@ -338,9 +346,15 @@ class _LRUCacheWrapperInstanceMethod(Generic[_R, _T]):
             pass
         # Python 3.14+ (PEP 649): prefer the lazy __annotate__ function,
         # see the matching logic in _LRUCacheWrapper.__init__.
-        try:
-            self.__annotate__ = wrapper.__annotate__
-        except AttributeError:
+        if sys.version_info >= (3, 14):
+            try:
+                self.__annotate__ = wrapper.__annotate__
+            except AttributeError:
+                try:
+                    self.__annotations__ = wrapper.__annotations__
+                except AttributeError:
+                    pass
+        else:
             try:
                 self.__annotations__ = wrapper.__annotations__
             except AttributeError:

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,10 @@ exclude = .git,.env,__pycache__,.eggs
 max-line-length = 88
 extend-select = B950
 ignore = N801,N802,N803,E252,W503,E133,E203,E501
+# The deferred annotations tests reference names defined after use on
+# purpose (PEP 649); flake8 flags those as undefined.
+per-file-ignores =
+    tests/test_deferred_annotations.py:F821
 
 [coverage:run]
 branch = True

--- a/tests/test_deferred_annotations.py
+++ b/tests/test_deferred_annotations.py
@@ -16,13 +16,13 @@ import pytest
 from async_lru import alru_cache
 
 
-py314 = pytest.mark.skipif(
+requires_py314 = pytest.mark.skipif(
     sys.version_info < (3, 14),
     reason="deferred annotation evaluation requires Python 3.14",
 )
 
 
-@py314
+@requires_py314
 async def test_deco_with_annotation_defined_after() -> None:
     @alru_cache(maxsize=1)
     async def get_foo() -> Foo:
@@ -36,7 +36,7 @@ async def test_deco_with_annotation_defined_after() -> None:
     assert await get_foo() is first
 
 
-@py314
+@requires_py314
 async def test_annotations_stay_lazy_like_lru_cache() -> None:
     @alru_cache(maxsize=1)
     async def get_foo_async() -> Foo:
@@ -58,7 +58,7 @@ async def test_annotations_stay_lazy_like_lru_cache() -> None:
     )
 
 
-@py314
+@requires_py314
 async def test_unresolvable_annotation_raises_only_on_access() -> None:
     @alru_cache(maxsize=1)
     async def broken() -> Missing:  # type: ignore[name-defined]  # noqa: F821
@@ -83,7 +83,7 @@ async def test_method_wrapping_partial_without_annotation_attributes() -> None:
     assert not hasattr(api.meth, "__annotations__")
 
 
-@py314
+@requires_py314
 async def test_method_annotations_stay_lazy() -> None:
     class Api:
         @alru_cache(maxsize=1)

--- a/tests/test_deferred_annotations.py
+++ b/tests/test_deferred_annotations.py
@@ -1,0 +1,81 @@
+"""Tests for PEP 649 deferred annotations (Python 3.14+).
+
+On Python 3.14 annotations are evaluated lazily via ``__annotate__``.
+Copying ``fn.__annotations__`` eagerly at decoration time forces that
+evaluation and crashes with ``NameError`` when the annotation refers to
+a name defined after the decorated function, a pattern that works with
+``functools.lru_cache``.
+"""
+
+import inspect
+import sys
+from functools import lru_cache
+
+import pytest
+
+from async_lru import alru_cache
+
+
+py314 = pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="deferred annotation evaluation requires Python 3.14",
+)
+
+
+@py314
+async def test_deco_with_annotation_defined_after() -> None:
+    @alru_cache(maxsize=1)
+    async def get_foo() -> Foo:
+        return Foo()
+
+    class Foo:
+        pass
+
+    first = await get_foo()
+    assert isinstance(first, Foo)
+    assert await get_foo() is first
+
+
+@py314
+async def test_annotations_stay_lazy_like_lru_cache() -> None:
+    @alru_cache(maxsize=1)
+    async def get_foo_async() -> Foo:
+        return Foo()
+
+    @lru_cache(maxsize=1)
+    def get_foo_sync() -> Foo:
+        return Foo()
+
+    class Foo:
+        pass
+
+    assert (
+        inspect.get_annotations(get_foo_async)
+        == inspect.get_annotations(get_foo_sync)
+        == {"return": Foo}
+    )
+
+
+@py314
+async def test_unresolvable_annotation_raises_only_on_access() -> None:
+    @alru_cache(maxsize=1)
+    async def broken() -> Missing:  # type: ignore[name-defined]  # noqa: F821
+        pass  # pragma: no cover
+
+    with pytest.raises(NameError):
+        inspect.get_annotations(broken)
+
+
+@py314
+async def test_method_annotations_stay_lazy() -> None:
+    class Api:
+        @alru_cache(maxsize=1)
+        async def get_foo(self) -> Foo:
+            return Foo()
+
+    class Foo:
+        pass
+
+    api = Api()
+    assert isinstance(await api.get_foo(), Foo)
+    assert inspect.get_annotations(api.get_foo) == {"return": Foo}

--- a/tests/test_deferred_annotations.py
+++ b/tests/test_deferred_annotations.py
@@ -9,7 +9,7 @@ a name defined after the decorated function, a pattern that works with
 
 import inspect
 import sys
-from functools import lru_cache
+from functools import lru_cache, partial
 
 import pytest
 
@@ -49,6 +49,8 @@ async def test_annotations_stay_lazy_like_lru_cache() -> None:
     class Foo:
         pass
 
+    assert isinstance(await get_foo_async(), Foo)
+    assert isinstance(get_foo_sync(), Foo)
     assert (
         inspect.get_annotations(get_foo_async)
         == inspect.get_annotations(get_foo_sync)
@@ -64,6 +66,21 @@ async def test_unresolvable_annotation_raises_only_on_access() -> None:
 
     with pytest.raises(NameError):
         inspect.get_annotations(broken)
+
+
+async def test_method_wrapping_partial_without_annotation_attributes() -> None:
+    """A wrapped ``partial`` carries neither ``__annotate__`` nor
+    ``__annotations__``; binding it as a method copies neither."""
+
+    async def impl(self: object) -> int:
+        return 42
+
+    class Api:
+        meth = alru_cache(partial(impl))
+
+    api = Api()
+    assert await api.meth() == 42
+    assert not hasattr(api.meth, "__annotations__")
 
 
 @py314


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix `alru_cache` crashing at decoration time on Python 3.14 when an annotation refers to a name defined after the decorated function. PEP 649 makes annotations lazy, and copying `fn.__annotations__` eagerly forces their evaluation; `functools.update_wrapper` copies the lazy `__annotate__` function on 3.14 instead, so both wrapper classes now do the same, keeping the `__annotations__` copy as the fallback for 3.13 and older. Laziness now matches `functools.lru_cache`: `inspect.get_annotations()` resolves once the name exists and raises `NameError` only on access when it never does.

## Are there changes in behavior for the user?

Only on Python 3.14: the wrapper no longer exposes an eagerly evaluated `__annotations__` attribute; annotations are reachable through `inspect.get_annotations()` and `typing.get_type_hints()`, matching `functools.lru_cache` there. No changes on 3.13 and older.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Fixes #773

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the CHANGES folder (N/A; CHANGES.rst is updated in release PRs in this repo)
