### PR TITLE
Add key parameter for custom cache key computation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,32 @@ affecting hit/miss counters or LRU ordering, use `cache_contains()`:
 The method returns `True` if the result for the given arguments is cached, `False`
 otherwise.
 
+Custom cache keys
+-----------------
+
+By default the cache key is built from all arguments, like
+``functools.lru_cache`` does. The ``key`` parameter accepts a callable that
+receives the same arguments as the wrapped function and returns the cache key,
+so arguments that do not affect the result can be excluded from it. This is an
+async-lru extension beyond the ``functools.lru_cache`` interface:
+
+.. code-block:: python
+
+    @alru_cache(key=lambda db, query: query)
+    async def query_db(db, query):
+        return await db.execute(query)
+
+    # Both calls share one cache entry despite the different connections.
+    await query_db(conn1, "SELECT ...")
+    await query_db(conn2, "SELECT ...")
+
+The returned key must be hashable. ``cache_invalidate()`` and
+``cache_contains()`` compute the key the same way, so they accept the full
+argument list as usual. For decorated methods the key callable receives the
+instance as its first argument. Passing ``typed=True`` together with ``key``
+raises ``ValueError``, since ``typed`` only affects the default key
+computation.
+
 Limitations
 -----------
 

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -156,23 +156,24 @@ class _LRUCacheWrapper(Generic[_R]):
             self.cache_clear()
             self.__first_loop = loop
 
-    def _make_cache_key(
-        self, fn_args: tuple[Any, ...], fn_kwargs: dict[str, Any]
-    ) -> Hashable:
-        if self.__key is not None:
-            return self.__key(*fn_args, **fn_kwargs)
-        return _make_key(fn_args, fn_kwargs, self.__typed)
-
     def cache_contains(self, /, *args: Hashable, **kwargs: Any) -> bool:
         """Check if the given arguments are in the cache.
 
         Does not affect hit/miss counters or LRU ordering.
         """
-        key = self._make_cache_key(args, kwargs)
+        # Inlined instead of a shared helper: an extra method call is
+        # measurable on these short code paths (CodSpeed).
+        if self.__key is not None:
+            key = self.__key(*args, **kwargs)
+        else:
+            key = _make_key(args, kwargs, self.__typed)
         return key in self.__cache
 
     def cache_invalidate(self, /, *args: Hashable, **kwargs: Any) -> bool:
-        key = self._make_cache_key(args, kwargs)
+        if self.__key is not None:
+            key = self.__key(*args, **kwargs)
+        else:
+            key = _make_key(args, kwargs, self.__typed)
 
         cache_item = self.__cache.pop(key, None)
         if cache_item is None:
@@ -271,7 +272,10 @@ class _LRUCacheWrapper(Generic[_R]):
         loop = asyncio.get_running_loop()
         self._check_loop(loop)
 
-        key = self._make_cache_key(fn_args, fn_kwargs)
+        if self.__key is not None:
+            key: Hashable = self.__key(*fn_args, **fn_kwargs)
+        else:
+            key = _make_key(fn_args, fn_kwargs, self.__typed)
         cache_item = self.__cache.get(key)
 
         if cache_item is not None:

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -118,12 +118,7 @@ class _LRUCacheWrapper(Generic[_R]):
         self.__typed = typed
         self.__ttl = ttl
         self.__jitter = jitter
-        if key is not None:
-            self.__key = key
-        else:
-            # Default: pack the call arguments the way functools._make_key
-            # expects, so __key is always callable.
-            self.__key = lambda *args, **kwargs: _make_key(args, kwargs, typed)
+        self.__key = key
         self.__cache: OrderedDict[Hashable, _CacheItem[_R]] = OrderedDict()
         self.__closed = False
         self.__hits = 0
@@ -166,10 +161,19 @@ class _LRUCacheWrapper(Generic[_R]):
 
         Does not affect hit/miss counters or LRU ordering.
         """
-        return self.__key(*args, **kwargs) in self.__cache
+        # Inlined instead of a shared helper: an extra method call is
+        # measurable on these short code paths (CodSpeed).
+        if self.__key is not None:
+            key = self.__key(*args, **kwargs)
+        else:
+            key = _make_key(args, kwargs, self.__typed)
+        return key in self.__cache
 
     def cache_invalidate(self, /, *args: Hashable, **kwargs: Any) -> bool:
-        key = self.__key(*args, **kwargs)
+        if self.__key is not None:
+            key = self.__key(*args, **kwargs)
+        else:
+            key = _make_key(args, kwargs, self.__typed)
 
         cache_item = self.__cache.pop(key, None)
         if cache_item is None:
@@ -268,7 +272,10 @@ class _LRUCacheWrapper(Generic[_R]):
         loop = asyncio.get_running_loop()
         self._check_loop(loop)
 
-        key = self.__key(*fn_args, **fn_kwargs)
+        if self.__key is not None:
+            key: Hashable = self.__key(*fn_args, **fn_kwargs)
+        else:
+            key = _make_key(fn_args, fn_kwargs, self.__typed)
         cache_item = self.__cache.get(key)
 
         if cache_item is not None:

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -64,6 +64,7 @@ class _LRUCacheWrapper(Generic[_R]):
         "__typed",
         "__ttl",
         "__jitter",
+        "__key",
         "__cache",
         "__closed",
         "__hits",
@@ -82,6 +83,7 @@ class _LRUCacheWrapper(Generic[_R]):
         typed: bool,
         ttl: float | None,
         jitter: float | None,
+        key: Callable[..., Hashable] | None = None,
     ) -> None:
         try:
             self.__module__ = fn.__module__
@@ -116,6 +118,7 @@ class _LRUCacheWrapper(Generic[_R]):
         self.__typed = typed
         self.__ttl = ttl
         self.__jitter = jitter
+        self.__key = key
         self.__cache: OrderedDict[Hashable, _CacheItem[_R]] = OrderedDict()
         self.__closed = False
         self.__hits = 0
@@ -153,16 +156,23 @@ class _LRUCacheWrapper(Generic[_R]):
             self.cache_clear()
             self.__first_loop = loop
 
+    def _make_cache_key(
+        self, fn_args: tuple[Any, ...], fn_kwargs: dict[str, Any]
+    ) -> Hashable:
+        if self.__key is not None:
+            return self.__key(*fn_args, **fn_kwargs)
+        return _make_key(fn_args, fn_kwargs, self.__typed)
+
     def cache_contains(self, /, *args: Hashable, **kwargs: Any) -> bool:
         """Check if the given arguments are in the cache.
 
         Does not affect hit/miss counters or LRU ordering.
         """
-        key = _make_key(args, kwargs, self.__typed)
+        key = self._make_cache_key(args, kwargs)
         return key in self.__cache
 
     def cache_invalidate(self, /, *args: Hashable, **kwargs: Any) -> bool:
-        key = _make_key(args, kwargs, self.__typed)
+        key = self._make_cache_key(args, kwargs)
 
         cache_item = self.__cache.pop(key, None)
         if cache_item is None:
@@ -261,7 +271,7 @@ class _LRUCacheWrapper(Generic[_R]):
         loop = asyncio.get_running_loop()
         self._check_loop(loop)
 
-        key = _make_key(fn_args, fn_kwargs, self.__typed)
+        key = self._make_cache_key(fn_args, fn_kwargs)
         cache_item = self.__cache.get(key)
 
         if cache_item is not None:
@@ -385,11 +395,16 @@ def _make_wrapper(
     typed: bool,
     ttl: float | None = None,
     jitter: float | None = None,
+    key: Callable[..., Hashable] | None = None,
 ) -> Callable[[_CBP[_R]], _LRUCacheWrapper[_R]]:
     if jitter is not None and ttl is None:
         raise ValueError("jitter requires ttl to be set")
     if jitter is not None and jitter < 0:
         raise ValueError("jitter must be non-negative")
+    if key is not None and not callable(key):
+        raise TypeError("key must be callable")
+    if key is not None and typed:
+        raise ValueError("typed is ignored when a custom key callable is provided")
 
     def wrapper(fn: _CBP[_R]) -> _LRUCacheWrapper[_R]:
         origin = fn
@@ -403,7 +418,7 @@ def _make_wrapper(
         if hasattr(fn, "_make_unbound_method"):
             fn = fn._make_unbound_method()
 
-        wrapper = _LRUCacheWrapper(cast(_CB[_R], fn), maxsize, typed, ttl, jitter)
+        wrapper = _LRUCacheWrapper(cast(_CB[_R], fn), maxsize, typed, ttl, jitter, key)
         if sys.version_info >= (3, 12):
             wrapper = inspect.markcoroutinefunction(wrapper)
         return wrapper
@@ -418,6 +433,7 @@ def alru_cache(
     *,
     ttl: float | None = None,
     jitter: float | None = None,
+    key: Callable[..., Hashable] | None = None,
 ) -> Callable[[_CBP[_R]], _LRUCacheWrapper[_R]]:
     ...
 
@@ -436,9 +452,10 @@ def alru_cache(
     *,
     ttl: float | None = None,
     jitter: float | None = None,
+    key: Callable[..., Hashable] | None = None,
 ) -> Callable[[_CBP[_R]], _LRUCacheWrapper[_R]] | _LRUCacheWrapper[_R]:
     if maxsize is None or isinstance(maxsize, int):
-        return _make_wrapper(maxsize, typed, ttl, jitter)
+        return _make_wrapper(maxsize, typed, ttl, jitter, key)
     else:
         fn = cast(_CB[_R], maxsize)
 

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -118,7 +118,12 @@ class _LRUCacheWrapper(Generic[_R]):
         self.__typed = typed
         self.__ttl = ttl
         self.__jitter = jitter
-        self.__key = key
+        if key is not None:
+            self.__key = key
+        else:
+            # Default: pack the call arguments the way functools._make_key
+            # expects, so __key is always callable.
+            self.__key = lambda *args, **kwargs: _make_key(args, kwargs, typed)
         self.__cache: OrderedDict[Hashable, _CacheItem[_R]] = OrderedDict()
         self.__closed = False
         self.__hits = 0
@@ -161,19 +166,10 @@ class _LRUCacheWrapper(Generic[_R]):
 
         Does not affect hit/miss counters or LRU ordering.
         """
-        # Inlined instead of a shared helper: an extra method call is
-        # measurable on these short code paths (CodSpeed).
-        if self.__key is not None:
-            key = self.__key(*args, **kwargs)
-        else:
-            key = _make_key(args, kwargs, self.__typed)
-        return key in self.__cache
+        return self.__key(*args, **kwargs) in self.__cache
 
     def cache_invalidate(self, /, *args: Hashable, **kwargs: Any) -> bool:
-        if self.__key is not None:
-            key = self.__key(*args, **kwargs)
-        else:
-            key = _make_key(args, kwargs, self.__typed)
+        key = self.__key(*args, **kwargs)
 
         cache_item = self.__cache.pop(key, None)
         if cache_item is None:
@@ -272,10 +268,7 @@ class _LRUCacheWrapper(Generic[_R]):
         loop = asyncio.get_running_loop()
         self._check_loop(loop)
 
-        if self.__key is not None:
-            key: Hashable = self.__key(*fn_args, **fn_kwargs)
-        else:
-            key = _make_key(fn_args, fn_kwargs, self.__typed)
+        key = self.__key(*fn_args, **fn_kwargs)
         cache_item = self.__cache.get(key)
 
         if cache_item is not None:

--- a/async_lru/__init__.py
+++ b/async_lru/__init__.py
@@ -273,7 +273,7 @@ class _LRUCacheWrapper(Generic[_R]):
         self._check_loop(loop)
 
         if self.__key is not None:
-            key: Hashable = self.__key(*fn_args, **fn_kwargs)
+            key = self.__key(*fn_args, **fn_kwargs)
         else:
             key = _make_key(fn_args, fn_kwargs, self.__typed)
         cache_item = self.__cache.get(key)

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -1,0 +1,145 @@
+import asyncio
+from collections.abc import Callable
+
+import pytest
+
+from async_lru import alru_cache
+
+
+async def test_key_excludes_argument(check_lru: Callable[..., None]) -> None:
+    """Calls differing only in the excluded argument share one entry."""
+
+    @alru_cache(key=lambda conn, query: query)
+    async def query_db(conn: str, query: str) -> str:
+        return f"{conn}={query}"
+
+    assert await query_db("conn1", "SELECT 1") == "conn1=SELECT 1"
+    check_lru(query_db, hits=0, misses=1, cache=1, tasks=0)
+
+    assert await query_db("conn2", "SELECT 1") == "conn1=SELECT 1"
+    check_lru(query_db, hits=1, misses=1, cache=1, tasks=0)
+
+    assert await query_db("conn2", "SELECT 2") == "conn2=SELECT 2"
+    check_lru(query_db, hits=1, misses=2, cache=2, tasks=0)
+
+
+async def test_key_receives_kwargs(check_lru: Callable[..., None]) -> None:
+    @alru_cache(key=lambda conn, *, query: query)
+    async def query_db(conn: str, *, query: str) -> str:
+        return f"{conn}={query}"
+
+    assert await query_db("conn1", query="q") == "conn1=q"
+    assert await query_db("conn2", query="q") == "conn1=q"
+    check_lru(query_db, hits=1, misses=1, cache=1, tasks=0)
+
+
+async def test_key_cache_invalidate(check_lru: Callable[..., None]) -> None:
+    """cache_invalidate computes the same custom key as the call did."""
+
+    @alru_cache(key=lambda conn, query: query)
+    async def query_db(conn: str, query: str) -> str:
+        return f"{conn}={query}"
+
+    await query_db("conn1", "SELECT 1")
+    check_lru(query_db, hits=0, misses=1, cache=1, tasks=0)
+
+    # A different excluded argument still addresses the same entry.
+    assert query_db.cache_invalidate("conn9", "SELECT 1")
+    check_lru(query_db, hits=0, misses=1, cache=0, tasks=0)
+    assert not query_db.cache_invalidate("conn9", "SELECT 1")
+
+
+async def test_key_cache_contains(check_lru: Callable[..., None]) -> None:
+    @alru_cache(key=lambda conn, query: query)
+    async def query_db(conn: str, query: str) -> str:
+        return f"{conn}={query}"
+
+    await query_db("conn1", "SELECT 1")
+    assert query_db.cache_contains("conn9", "SELECT 1")
+    assert not query_db.cache_contains("conn9", "SELECT 2")
+
+
+def test_key_with_typed_raises() -> None:
+    with pytest.raises(ValueError, match="typed"):
+        alru_cache(typed=True, key=lambda x: x)
+
+
+def test_key_not_callable() -> None:
+    with pytest.raises(TypeError, match="callable"):
+        alru_cache(key="query")  # type: ignore[call-overload]
+
+
+async def test_typed_without_key_still_works() -> None:
+    @alru_cache(typed=True)
+    async def coro(val: int) -> int:
+        return val
+
+    assert coro.cache_parameters()["typed"] is True
+    assert await coro(1) == 1
+
+
+async def test_key_on_method(check_lru: Callable[..., None]) -> None:
+    """The key callable receives the instance for bound methods."""
+
+    class Api:
+        @alru_cache(key=lambda self, query: query)
+        async def fetch(self, query: str) -> str:
+            return f"{id(self)}={query}"
+
+    first = Api()
+    second = Api()
+    result = await first.fetch("SELECT 1")
+    # Another instance shares the entry since self is excluded.
+    assert await second.fetch("SELECT 1") == result
+    check_lru(Api.fetch, hits=1, misses=1, cache=1, tasks=0)
+
+
+async def test_key_unhashable_result(check_lru: Callable[..., None]) -> None:
+    @alru_cache(key=lambda val: [val])  # type: ignore[arg-type,return-value]
+    async def coro(val: int) -> int:
+        return val  # pragma: no cover  # the key fails before the call
+
+    with pytest.raises(TypeError, match="unhashable"):
+        await coro(1)
+    check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
+
+
+async def test_key_callable_raising(check_lru: Callable[..., None]) -> None:
+    def broken_key(val: int) -> int:
+        raise RuntimeError("broken key")
+
+    @alru_cache(key=broken_key)
+    async def coro(val: int) -> int:
+        return val  # pragma: no cover  # the key fails before the call
+
+    with pytest.raises(RuntimeError, match="broken key"):
+        await coro(1)
+    check_lru(coro, hits=0, misses=0, cache=0, tasks=0)
+
+
+async def test_key_with_ttl(check_lru: Callable[..., None]) -> None:
+    @alru_cache(ttl=0.05, key=lambda conn, query: query)
+    async def query_db(conn: str, query: str) -> str:
+        return f"{conn}={query}"
+
+    await query_db("conn1", "SELECT 1")
+    assert await query_db("conn2", "SELECT 1") == "conn1=SELECT 1"
+    check_lru(query_db, hits=1, misses=1, cache=1, tasks=0)
+
+    await asyncio.sleep(0.06)
+    assert await query_db("conn2", "SELECT 1") == "conn2=SELECT 1"
+    check_lru(query_db, hits=1, misses=2, cache=1, tasks=0)
+
+
+async def test_key_with_maxsize(check_lru: Callable[..., None]) -> None:
+    @alru_cache(maxsize=1, key=lambda conn, query: query)
+    async def query_db(conn: str, query: str) -> str:
+        return f"{conn}={query}"
+
+    await query_db("conn1", "SELECT 1")
+    await query_db("conn1", "SELECT 2")
+    check_lru(query_db, hits=0, misses=2, cache=1, tasks=0, maxsize=1)
+
+    # The first entry was evicted; same query recomputes.
+    assert await query_db("conn2", "SELECT 1") == "conn2=SELECT 1"
+    check_lru(query_db, hits=0, misses=3, cache=1, tasks=0, maxsize=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add an optional `key` parameter to `alru_cache` for custom cache key computation, so arguments that do not affect the result can be excluded from the key (the motivating case in #619: a DB connection passed alongside a query). The callable receives the same arguments as the wrapped function and its hashable result replaces the default `functools._make_key` tuple. `cache_invalidate()` and `cache_contains()` compute keys the same way, so a custom key invalidates exactly what it cached. `typed=True` combined with `key` raises `ValueError`, since `typed` only affects the default computation. With `key` unset (the default), behavior is unchanged, keeping the stdlib-mirroring interface intact; the README documents the parameter as an async-lru extension beyond the `lru_cache` interface.

On the stdlib-compatibility question from the issue discussion: there was an upstream proposal, python/cpython#90780 (bpo-46622, 2022), which was closed in favor of a separate implementation rather than extending `lru_cache` to coroutines; the `functools` docs were later amended (python/cpython#107619) to note that caching async functions with `lru_cache` "doesn't make sense". Whatever shape a future stdlib solution might take, reconciling stays easy because `key=None` keeps the mirror exact.

## Are there changes in behavior for the user?

Only when the new parameter is used. Without `key`, everything is unchanged.

## Is it a substantial burden for the maintainers to support this?

No. The feature is a single code path shared by the three key computation sites and is fully covered by tests.

## Related issue number

Fixes #619

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the CHANGES folder (N/A; CHANGES.rst is updated in release PRs in this repo)

